### PR TITLE
[#1] 약관 조회 기능 개발 및 기본 응답 포맷 정리

### DIFF
--- a/src/main/java/com/onerty/yeogi/YeogiApplication.java
+++ b/src/main/java/com/onerty/yeogi/YeogiApplication.java
@@ -2,8 +2,10 @@ package com.onerty.yeogi;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class YeogiApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/onerty/yeogi/exception/ErrorType.java
+++ b/src/main/java/com/onerty/yeogi/exception/ErrorType.java
@@ -1,0 +1,32 @@
+package com.onerty.yeogi.exception;
+
+import org.springframework.http.HttpStatus;
+
+public enum ErrorType {
+
+    TERMS_NOT_FOUND("a0001", HttpStatus.NOT_FOUND, "저장된 약관 내역이 없습니다"),
+
+    INTERNAL_SERVER_ERROR("common", HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류");
+
+    private String code;
+    private HttpStatus httpStatus;
+    private String message;
+
+    ErrorType(String code, HttpStatus httpStatus, String message) {
+        this.code = code;
+        this.httpStatus = httpStatus;
+        this.message = message;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/com/onerty/yeogi/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/onerty/yeogi/exception/GlobalExceptionHandler.java
@@ -1,0 +1,35 @@
+package com.onerty.yeogi.exception;
+
+import com.onerty.yeogi.util.BaseResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+
+import static com.onerty.yeogi.exception.ErrorType.INTERNAL_SERVER_ERROR;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(YeogiException.class)
+    public ResponseEntity<BaseResponse.error> handleYeogiException(YeogiException ex, WebRequest request) {
+        ErrorType errorType = ex.getErrorType();
+
+        BaseResponse.error errorResponse = new BaseResponse.error(
+                request.getDescription(false),
+                errorType
+        );
+
+        return ResponseEntity.status(errorType.getHttpStatus().value()).body(errorResponse);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<BaseResponse.error> handleGenericException(Exception ex, WebRequest request) {
+        BaseResponse.error errorResponse = new BaseResponse.error(
+                request.getDescription(false),
+                INTERNAL_SERVER_ERROR
+        );
+
+        return ResponseEntity.status(500).body(errorResponse);
+    }
+}

--- a/src/main/java/com/onerty/yeogi/exception/YeogiException.java
+++ b/src/main/java/com/onerty/yeogi/exception/YeogiException.java
@@ -1,0 +1,13 @@
+package com.onerty.yeogi.exception;
+
+public class YeogiException extends RuntimeException {
+    ErrorType errorType;
+
+    public YeogiException(ErrorType errorType) {
+        this.errorType = errorType;
+    }
+
+    public ErrorType getErrorType() {
+        return errorType;
+    }
+}

--- a/src/main/java/com/onerty/yeogi/term/Term.java
+++ b/src/main/java/com/onerty/yeogi/term/Term.java
@@ -1,0 +1,37 @@
+package com.onerty.yeogi.term;
+
+
+import com.onerty.yeogi.util.BaseEntity;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+
+@Entity
+@Table(name = "terms")
+@Getter
+@Setter
+public class Term extends BaseEntity {
+
+    @Id
+    @GeneratedValue
+    private Long termId;
+
+    private String title;
+    private boolean isRequired;
+
+    @OneToMany(mappedBy = "term")
+    private List<TermDetail> termDetails;
+
+    @Override
+    public String toString() {
+        return "Term{" +
+                "termId=" + termId +
+                ", title='" + title + '\'' +
+                ", isRequired=" + isRequired +
+                ", termDetails=" + termDetails +
+                '}';
+    }
+}

--- a/src/main/java/com/onerty/yeogi/term/TermDetail.java
+++ b/src/main/java/com/onerty/yeogi/term/TermDetail.java
@@ -1,0 +1,22 @@
+package com.onerty.yeogi.term;
+
+import com.onerty.yeogi.util.BaseEntity;
+import jakarta.persistence.*;
+import lombok.Getter;
+
+@Entity
+@Getter
+public class TermDetail extends BaseEntity {
+
+    @Id
+    @GeneratedValue
+    private Long termDetailId;
+
+    @ManyToOne
+    private Term term;
+
+    @Column(columnDefinition = "TEXT")
+    private String content;
+    private Integer version;
+    
+}

--- a/src/main/java/com/onerty/yeogi/term/TermRepository.java
+++ b/src/main/java/com/onerty/yeogi/term/TermRepository.java
@@ -1,0 +1,23 @@
+package com.onerty.yeogi.term;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface TermRepository extends JpaRepository<Term, Long> {
+    @Query("""
+            SELECT t
+            FROM Term t
+            JOIN FETCH t.termDetails td
+            WHERE td.version = (
+                SELECT MAX(tdSub.version)
+                FROM TermDetail tdSub
+                WHERE tdSub.term = t
+            )
+            """)
+    List<Term> findTermsWithLatestTermDetail();
+
+}

--- a/src/main/java/com/onerty/yeogi/term/dto/TermDto.java
+++ b/src/main/java/com/onerty/yeogi/term/dto/TermDto.java
@@ -1,0 +1,4 @@
+package com.onerty.yeogi.term.dto;
+
+public record TermDto(Long id, String title, String content, boolean isRequired) {
+}

--- a/src/main/java/com/onerty/yeogi/term/dto/TermResponse.java
+++ b/src/main/java/com/onerty/yeogi/term/dto/TermResponse.java
@@ -1,0 +1,6 @@
+package com.onerty.yeogi.term.dto;
+
+import java.util.List;
+
+public record TermResponse(List<TermDto> terms) {
+}

--- a/src/main/java/com/onerty/yeogi/user/UserController.java
+++ b/src/main/java/com/onerty/yeogi/user/UserController.java
@@ -1,0 +1,23 @@
+package com.onerty.yeogi.user;
+
+
+import com.onerty.yeogi.term.dto.TermResponse;
+import com.onerty.yeogi.util.BaseResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/users")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    @GetMapping("/v1/terms/agree")
+    public BaseResponse<TermResponse> getTerms() {
+        return new BaseResponse.success<>(userService.getTerms());
+    }
+
+}

--- a/src/main/java/com/onerty/yeogi/user/UserService.java
+++ b/src/main/java/com/onerty/yeogi/user/UserService.java
@@ -1,5 +1,7 @@
 package com.onerty.yeogi.user;
 
+import com.onerty.yeogi.exception.ErrorType;
+import com.onerty.yeogi.exception.YeogiException;
 import com.onerty.yeogi.term.Term;
 import com.onerty.yeogi.term.TermRepository;
 import com.onerty.yeogi.term.dto.TermDto;
@@ -20,6 +22,9 @@ public class UserService {
 
     public TermResponse getTerms() {
         List<Term> terms = termRepository.findTermsWithLatestTermDetail();
+        if (terms.isEmpty()) {
+            throw new YeogiException(ErrorType.TERMS_NOT_FOUND);
+        }
 
         List<TermDto> termDtos = terms.stream()
                 .map(term -> new TermDto(

--- a/src/main/java/com/onerty/yeogi/user/UserService.java
+++ b/src/main/java/com/onerty/yeogi/user/UserService.java
@@ -1,0 +1,36 @@
+package com.onerty.yeogi.user;
+
+import com.onerty.yeogi.term.Term;
+import com.onerty.yeogi.term.TermRepository;
+import com.onerty.yeogi.term.dto.TermDto;
+import com.onerty.yeogi.term.dto.TermResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final TermRepository termRepository;
+
+    public TermResponse getTerms() {
+        List<Term> terms = termRepository.findTermsWithLatestTermDetail();
+
+        List<TermDto> termDtos = terms.stream()
+                .map(term -> new TermDto(
+                        term.getTermId(),
+                        term.getTitle(),
+                        term.getTermDetails().isEmpty() ? "" : term.getTermDetails().get(0).getContent(),
+                        term.isRequired()
+                ))
+                .collect(Collectors.toList());
+
+        return new TermResponse(termDtos);
+    }
+
+}

--- a/src/main/java/com/onerty/yeogi/util/BaseEntity.java
+++ b/src/main/java/com/onerty/yeogi/util/BaseEntity.java
@@ -1,0 +1,24 @@
+package com.onerty.yeogi.util;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+@MappedSuperclass
+public class BaseEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/onerty/yeogi/util/BaseResponse.java
+++ b/src/main/java/com/onerty/yeogi/util/BaseResponse.java
@@ -1,0 +1,43 @@
+package com.onerty.yeogi.util;
+
+import com.onerty.yeogi.exception.ErrorType;
+import lombok.Getter;
+
+@Getter
+public class BaseResponse<T> {
+    private final T data;
+    private final Meta meta;
+
+    public BaseResponse(T data, Meta meta) {
+        this.data = data;
+        this.meta = meta;
+    }
+
+    public record Meta(String message, String code) {
+    }
+
+    public static class success<T> extends BaseResponse<T> {
+        public success(T data) {
+            super(data, new Meta(null, null));
+        }
+    }
+
+    @Getter
+    public static class error {
+        private final String url;
+        private final int statusCode;
+        private final String statusMessage;
+        private final String message;
+        private final String stack;
+        private final Meta meta;
+
+        public error(String url, ErrorType errorType) {
+            this.url = url;
+            this.statusCode = errorType.getHttpStatus().value();
+            this.statusMessage = errorType.getHttpStatus().name();
+            this.message = errorType.getMessage();
+            this.stack = "";
+            this.meta = new Meta(message, errorType.getCode());
+        }
+    }
+}


### PR DESCRIPTION
## 주요 구현 내용

- 약관 엔티티 (`Term`, `TermDetail`)
    - 변경 이력을 관리하기 위해 엔티티를 분리합니다
    - `Term` 은 약관 기본 정보(제목, 필수 여부)를 관리하고 `TermDetail` 은 개별 버전의 약관 내용을 저장합니다
- 기본 응답 처리 (`BaseResponse`)
    - API 응답을 성공과 오류로 분리해 일관된 형식으로 반환합니다
- 예외 처리
    - 어플리케이션에서 발생하는 도메인 예외를 처리하기 위해 `YeogiException` 커스텀 예외 클래스를 만들었습니다
    - `ErrorType` enum 을 사용해 오류 유형을 관리합니다
    - `GlobalExceptionHandler` 에서 예외를 감지해 BaseResponse.error 형식으로 오류 응답을 반환합니다
