### PR TITLE
[#2] 랜덤 닉네임 조회

### DIFF
--- a/src/main/java/com/onerty/yeogi/user/Nickname.java
+++ b/src/main/java/com/onerty/yeogi/user/Nickname.java
@@ -1,0 +1,25 @@
+package com.onerty.yeogi.user;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Nickname {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    private NicknameType type;
+
+    private String value;
+
+    public Nickname(NicknameType type, String value) {
+        this.type = type;
+        this.value = value;
+    }
+}

--- a/src/main/java/com/onerty/yeogi/user/NicknameRepository.java
+++ b/src/main/java/com/onerty/yeogi/user/NicknameRepository.java
@@ -1,0 +1,9 @@
+package com.onerty.yeogi.user;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface NicknameRepository extends JpaRepository<Nickname, Long> {
+    List<Nickname> findByType(NicknameType type);
+}

--- a/src/main/java/com/onerty/yeogi/user/NicknameType.java
+++ b/src/main/java/com/onerty/yeogi/user/NicknameType.java
@@ -1,0 +1,5 @@
+package com.onerty.yeogi.user;
+
+public enum NicknameType {
+    ADJECTIVE1, ADJECTIVE2, NOUN
+}

--- a/src/main/java/com/onerty/yeogi/user/UserController.java
+++ b/src/main/java/com/onerty/yeogi/user/UserController.java
@@ -2,6 +2,7 @@ package com.onerty.yeogi.user;
 
 
 import com.onerty.yeogi.term.dto.TermResponse;
+import com.onerty.yeogi.user.dto.NicknameResponse;
 import com.onerty.yeogi.util.BaseResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -20,4 +21,8 @@ public class UserController {
         return new BaseResponse.success<>(userService.getTerms());
     }
 
+    @GetMapping("/v1/nicknames-recommendation")
+    public BaseResponse<NicknameResponse> getNicknames() {
+        return new BaseResponse.success<>(userService.generateRandomNicknames());
+    }
 }

--- a/src/main/java/com/onerty/yeogi/user/UserService.java
+++ b/src/main/java/com/onerty/yeogi/user/UserService.java
@@ -6,10 +6,12 @@ import com.onerty.yeogi.term.Term;
 import com.onerty.yeogi.term.TermRepository;
 import com.onerty.yeogi.term.dto.TermDto;
 import com.onerty.yeogi.term.dto.TermResponse;
+import com.onerty.yeogi.user.dto.NicknameResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -19,6 +21,7 @@ import java.util.stream.Collectors;
 public class UserService {
 
     private final TermRepository termRepository;
+    private final NicknameRepository nicknameRepository;
 
     public TermResponse getTerms() {
         List<Term> terms = termRepository.findTermsWithLatestTermDetail();
@@ -36,6 +39,35 @@ public class UserService {
                 .collect(Collectors.toList());
 
         return new TermResponse(termDtos);
+    }
+
+    public NicknameResponse generateRandomNicknames() {
+        List<String> adjectives1 = nicknameRepository.findByType(NicknameType.ADJECTIVE1)
+                .stream()
+                .map(Nickname::getValue)
+                .toList();
+
+        List<String> adjectives2 = nicknameRepository.findByType(NicknameType.ADJECTIVE2)
+                .stream()
+                .map(Nickname::getValue)
+                .toList();
+
+        List<String> nouns = nicknameRepository.findByType(NicknameType.NOUN)
+                .stream()
+                .map(Nickname::getValue)
+                .toList();
+
+        List<String> nicknames = adjectives1.stream()
+                .flatMap(adj1 -> adjectives2.stream()
+                        .flatMap(adj2 -> nouns.stream()
+                                .map(noun -> adj1 + adj2 + noun)))
+                .collect(Collectors.toList());
+
+        Collections.shuffle(nicknames);
+
+        return new NicknameResponse(nicknames.stream()
+                .limit(20)
+                .collect(Collectors.toList()));
     }
 
 }

--- a/src/main/java/com/onerty/yeogi/user/dto/NicknameResponse.java
+++ b/src/main/java/com/onerty/yeogi/user/dto/NicknameResponse.java
@@ -1,0 +1,6 @@
+package com.onerty.yeogi.user.dto;
+
+import java.util.List;
+
+public record NicknameResponse(List<String> nicknames) {
+}


### PR DESCRIPTION
## 주요 구현 내용

- 닉네임 데이터를 저장할 엔티티 추가
- 타입 별 데이터 조회 후 조합해서 랜덤 닉네임 리스트 반환