### PR TITLE
[#7] 회원가입 (약관 동의 포함)

### DIFF
--- a/src/main/java/com/onerty/yeogi/exception/ErrorType.java
+++ b/src/main/java/com/onerty/yeogi/exception/ErrorType.java
@@ -11,7 +11,7 @@ public enum ErrorType {
     INVALID_EMAIL_FORMAT("a0005", HttpStatus.BAD_REQUEST, "이메일 형식이 올바르지 않습니다"),
     DUPLICATE_NICKNAME("a0006", HttpStatus.CONFLICT, "이미 사용 중인 닉네임입니다"),
     DUPLICATE_EMAIL("a0007", HttpStatus.CONFLICT, "이미 사용 중인 이메일입니다"),
-
+    SIGNUP_MISSING_REQUIRED_FIELD("a0008",  HttpStatus.BAD_REQUEST, "회원가입 필수 입력값이 누락되었습니다"),
 
     INTERNAL_SERVER_ERROR("common", HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류");
 

--- a/src/main/java/com/onerty/yeogi/exception/ErrorType.java
+++ b/src/main/java/com/onerty/yeogi/exception/ErrorType.java
@@ -7,6 +7,8 @@ public enum ErrorType {
     TERMS_NOT_FOUND("a0001", HttpStatus.NOT_FOUND, "저장된 약관 내역이 없습니다"),
     SMS_AUTH_MISSING_REQUIRED_FIELD("a0002", HttpStatus.BAD_REQUEST, "sms 인증 필수 입력값이 누락되었습니다"),
     SMS_AUTH_FAILED("a0003", HttpStatus.UNAUTHORIZED, "sms 인증에 실패했습니다"),
+    INVALID_PASSWORD_FORMAT("a0004", HttpStatus.BAD_REQUEST, "비밀번호 형식이 올바르지 않습니다"),
+    INVALID_EMAIL_FORMAT("a0005", HttpStatus.BAD_REQUEST, "이메일 형식이 올바르지 않습니다"),
 
     INTERNAL_SERVER_ERROR("common", HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류");
 

--- a/src/main/java/com/onerty/yeogi/exception/ErrorType.java
+++ b/src/main/java/com/onerty/yeogi/exception/ErrorType.java
@@ -9,6 +9,9 @@ public enum ErrorType {
     SMS_AUTH_FAILED("a0003", HttpStatus.UNAUTHORIZED, "sms 인증에 실패했습니다"),
     INVALID_PASSWORD_FORMAT("a0004", HttpStatus.BAD_REQUEST, "비밀번호 형식이 올바르지 않습니다"),
     INVALID_EMAIL_FORMAT("a0005", HttpStatus.BAD_REQUEST, "이메일 형식이 올바르지 않습니다"),
+    DUPLICATE_NICKNAME("a0006", HttpStatus.CONFLICT, "이미 사용 중인 닉네임입니다"),
+    DUPLICATE_EMAIL("a0007", HttpStatus.CONFLICT, "이미 사용 중인 이메일입니다"),
+
 
     INTERNAL_SERVER_ERROR("common", HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류");
 

--- a/src/main/java/com/onerty/yeogi/term/Agreement.java
+++ b/src/main/java/com/onerty/yeogi/term/Agreement.java
@@ -1,0 +1,20 @@
+package com.onerty.yeogi.term;
+
+import com.onerty.yeogi.util.BaseEntity;
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Agreement extends BaseEntity {
+
+    @EmbeddedId
+    private AgreementId agreementId;
+
+    private boolean isAgreed;
+
+}

--- a/src/main/java/com/onerty/yeogi/term/AgreementId.java
+++ b/src/main/java/com/onerty/yeogi/term/AgreementId.java
@@ -1,0 +1,28 @@
+package com.onerty.yeogi.term;
+
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+
+import java.util.Objects;
+
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class AgreementId {
+    private Long userId;
+    private Long termId;
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) return false;
+        AgreementId that = (AgreementId) o;
+        return Objects.equals(userId, that.userId) && Objects.equals(termId, that.termId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(userId, termId);
+    }
+}

--- a/src/main/java/com/onerty/yeogi/term/AgreementRepository.java
+++ b/src/main/java/com/onerty/yeogi/term/AgreementRepository.java
@@ -1,0 +1,17 @@
+package com.onerty.yeogi.term;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
+
+public interface AgreementRepository extends JpaRepository<Agreement, Long> {
+
+    @Query("""
+            SELECT a.isAgreed
+            FROM Agreement a
+            WHERE a.agreementId.userId = :userId
+              AND a.agreementId.termId = :termId
+            """)
+    Optional<Boolean> findIsAgreedByAgreementId(Long userId, Long termId);
+}

--- a/src/main/java/com/onerty/yeogi/user/User.java
+++ b/src/main/java/com/onerty/yeogi/user/User.java
@@ -1,0 +1,58 @@
+package com.onerty.yeogi.user;
+
+
+import com.onerty.yeogi.user.dto.UserSignupRequest;
+import com.onerty.yeogi.util.BaseEntity;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+
+@Entity
+@Table(name = "users")
+@Getter
+@Setter
+@NoArgsConstructor
+public class User extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id")  // 명시적으로 컬럼명을 설정
+    private Long userId;
+
+    @Column(name = "user_type")
+    private int userType;
+
+    @Column(name = "nickname")
+    private String nickname;
+
+    @Column(name = "phone_number")
+    private String phoneNumber;
+
+    @Column(name = "gender")
+    private String gender;
+
+    @Column(name = "birth_date")
+    private String birthDate;
+
+    @Column(name = "affiliate_user_id")
+    private String affiliateUserId;
+
+    @Column(name = "user_identifier")
+    private String userIdentifier;
+
+    @Column(name = "user_password")
+    private String userPassword;
+
+    public User(UserSignupRequest dto) {
+        this.userType = dto.utype();
+        this.nickname = dto.unick();
+        this.phoneNumber = dto.phoneNumber();
+        this.gender = dto.ugender();
+        this.birthDate = dto.ubirth();
+        this.affiliateUserId = dto.afUserId();
+        this.userIdentifier = dto.uid();
+        this.userPassword = dto.upw();
+    }
+}

--- a/src/main/java/com/onerty/yeogi/user/UserController.java
+++ b/src/main/java/com/onerty/yeogi/user/UserController.java
@@ -3,6 +3,8 @@ package com.onerty.yeogi.user;
 
 import com.onerty.yeogi.term.dto.TermResponse;
 import com.onerty.yeogi.user.dto.NicknameResponse;
+import com.onerty.yeogi.user.dto.UserSignupRequest;
+import com.onerty.yeogi.user.dto.UserSignupResponse;
 import com.onerty.yeogi.util.BaseResponse;
 import com.onerty.yeogi.util.MessageResponse;
 import lombok.RequiredArgsConstructor;
@@ -16,6 +18,12 @@ import java.util.Map;
 public class UserController {
 
     private final UserService userService;
+
+    @PostMapping("/signup")
+    public BaseResponse<UserSignupResponse> signup(@RequestBody UserSignupRequest signupDto) {
+        UserSignupResponse response = userService.registerUser(signupDto);
+        return new BaseResponse.success<>(response);
+    }
 
     @GetMapping("/v1/terms/agree")
     public BaseResponse<TermResponse> getTerms() {

--- a/src/main/java/com/onerty/yeogi/user/UserRepository.java
+++ b/src/main/java/com/onerty/yeogi/user/UserRepository.java
@@ -1,0 +1,12 @@
+package com.onerty.yeogi.user;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    boolean existsByUserIdentifier(String email);
+
+    boolean existsByNickname(String nickname);
+}

--- a/src/main/java/com/onerty/yeogi/user/UserService.java
+++ b/src/main/java/com/onerty/yeogi/user/UserService.java
@@ -33,6 +33,7 @@ public class UserService {
 
     @Transactional
     public UserSignupResponse registerUser(UserSignupRequest signupDto) {
+        signupDto.check();
         User user = new User(signupDto);
         validateDuplicateUserAttributes(user);
         userRepository.save(user);

--- a/src/main/java/com/onerty/yeogi/user/dto/UserSignupRequest.java
+++ b/src/main/java/com/onerty/yeogi/user/dto/UserSignupRequest.java
@@ -1,0 +1,44 @@
+package com.onerty.yeogi.user.dto;
+
+import com.github.ownert.yeogi.exception.ErrorType;
+import com.github.ownert.yeogi.exception.YeogiException;
+import com.github.ownert.yeogi.util.Checkable;
+
+import java.util.regex.Pattern;
+
+public record UserSignupRequest(
+        int utype,
+        String unick,
+        String phoneNumber,
+        String ugender,
+        String ubirth,
+        String afUserId,
+        boolean locationPolicy,
+        boolean privacyAuxiliaryPolicy,
+        boolean marketingAcceptance,
+        String uid,
+        String upw
+) implements Checkable {
+
+    private static final Pattern EMAIL_PATTERN =
+            Pattern.compile("^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,6}$");
+
+    private static final Pattern PASSWORD_PATTERN =
+            Pattern.compile("^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{8,}$");
+
+    @Override
+    public void check() {
+
+        if (unick == null || unick.isBlank() || phoneNumber == null || phoneNumber.isBlank()) {
+            throw new YeogiException(ErrorType.SIGNUP_MISSING_REQUIRED_FIELD);
+        }
+
+        if (uid == null || !EMAIL_PATTERN.matcher(uid).matches()) {
+            throw new YeogiException(ErrorType.INVALID_EMAIL_FORMAT);
+        }
+
+        if (upw == null || !PASSWORD_PATTERN.matcher(upw).matches()) {
+            throw new YeogiException(ErrorType.INVALID_PASSWORD_FORMAT);
+        }
+    }
+}

--- a/src/main/java/com/onerty/yeogi/user/dto/UserSignupRequest.java
+++ b/src/main/java/com/onerty/yeogi/user/dto/UserSignupRequest.java
@@ -1,8 +1,8 @@
 package com.onerty.yeogi.user.dto;
 
-import com.github.ownert.yeogi.exception.ErrorType;
-import com.github.ownert.yeogi.exception.YeogiException;
-import com.github.ownert.yeogi.util.Checkable;
+import com.onerty.yeogi.exception.YeogiException;
+import com.onerty.yeogi.exception.ErrorType;
+import com.onerty.yeogi.util.Checkable;
 
 import java.util.regex.Pattern;
 

--- a/src/main/java/com/onerty/yeogi/user/dto/UserSignupResponse.java
+++ b/src/main/java/com/onerty/yeogi/user/dto/UserSignupResponse.java
@@ -1,0 +1,7 @@
+package com.onerty.yeogi.user.dto;
+
+public record UserSignupResponse(
+        String uno,
+        boolean marketingAcceptance
+) {
+}


### PR DESCRIPTION
## 주요 구현 내용

- 회원가입 추가
    - 요청 객체의 유효성을 검증 후 사용자 정보를 저장
    - 닉네임 및 이메일 중복 확인 후 예외 처리
    - 회원가입 성공 시 회원 ID 및 마케팅 동의 여부 반환
- 약관 동의 처리 로직 추가 
    - 약관 동의 저장을 위한 `Agreement` 엔티티 추가
    - `UserId`와 `TermId`를 조합하여 `AgreementId`로 관리