### PR TITLE
회원가입 로직 및 약관 동의 처리 개선

### DIFF
--- a/src/main/java/com/onerty/yeogi/exception/ErrorType.java
+++ b/src/main/java/com/onerty/yeogi/exception/ErrorType.java
@@ -11,7 +11,9 @@ public enum ErrorType {
     INVALID_EMAIL_FORMAT("a0005", HttpStatus.BAD_REQUEST, "이메일 형식이 올바르지 않습니다"),
     DUPLICATE_NICKNAME("a0006", HttpStatus.CONFLICT, "이미 사용 중인 닉네임입니다"),
     DUPLICATE_EMAIL("a0007", HttpStatus.CONFLICT, "이미 사용 중인 이메일입니다"),
-    SIGNUP_MISSING_REQUIRED_FIELD("a0008",  HttpStatus.BAD_REQUEST, "회원가입 필수 입력값이 누락되었습니다"),
+    SIGNUP_MISSING_REQUIRED_FIELD("a0008", HttpStatus.BAD_REQUEST, "회원가입 필수 입력값이 누락되었습니다"),
+    SIGNUP_INVALID_TERM_ID("a0009", HttpStatus.BAD_REQUEST, "유효하지 않은 약관 ID입니다."),
+    SIGNUP_REQUIRED_TERMS_NOT_ACCEPTED("a0010", HttpStatus.BAD_REQUEST, "필수 약관에 동의하지 않았습니다."),
 
     INTERNAL_SERVER_ERROR("common", HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류");
 

--- a/src/main/java/com/onerty/yeogi/term/AgreementRepository.java
+++ b/src/main/java/com/onerty/yeogi/term/AgreementRepository.java
@@ -14,6 +14,6 @@ public interface AgreementRepository extends JpaRepository<Agreement, Long> {
             WHERE a.agreementId.user = :user
               AND a.agreementId.title = :title
             """)
-    Optional<Boolean> findIsAgreedByAgreementId(User user, String title);
+    Optional<Boolean> findIsAgreedByUserAndTitle(User user, String title);
 
 }

--- a/src/main/java/com/onerty/yeogi/term/TermTitle.java
+++ b/src/main/java/com/onerty/yeogi/term/TermTitle.java
@@ -1,0 +1,25 @@
+package com.onerty.yeogi.term;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.Arrays;
+
+@Getter
+@AllArgsConstructor
+public enum TermTitle {
+    TERMS_OF_SERVICE("이용약관"),
+    PRIVACY_POLICY("개인정보 수집 이용 동의"),
+    MARKETING_CONSENT("마케팅 수집 동의"),
+    LOCATION_SERVICE_CONSENT("위치기반 서비스 이용약관 동의");
+
+    private final String koreanTitle;
+
+    public static TermTitle fromKoreanTitle(String koreanTitle) {
+        return Arrays.stream(values())
+                .filter(t -> t.koreanTitle.equals(koreanTitle))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("Unknown title: " + koreanTitle));
+    }
+
+}

--- a/src/main/java/com/onerty/yeogi/user/UserController.java
+++ b/src/main/java/com/onerty/yeogi/user/UserController.java
@@ -21,6 +21,7 @@ public class UserController {
 
     @PostMapping("/signup")
     public BaseResponse<UserSignupResponse> signup(@RequestBody UserSignupRequest signupDto) {
+        signupDto.check();
         UserSignupResponse response = userService.registerUser(signupDto);
         return new BaseResponse.success<>(response);
     }

--- a/src/main/java/com/onerty/yeogi/user/UserService.java
+++ b/src/main/java/com/onerty/yeogi/user/UserService.java
@@ -33,7 +33,6 @@ public class UserService {
     private final StringRedisTemplate redisTemplate;
 
     public UserSignupResponse registerUser(UserSignupRequest signupDto) {
-        signupDto.check();
         validateDuplicateUserAttributes(signupDto.uid(), signupDto.unick());
         validateLatestAndRequiredTerms(signupDto.agreements());
 

--- a/src/main/java/com/onerty/yeogi/user/UserService.java
+++ b/src/main/java/com/onerty/yeogi/user/UserService.java
@@ -17,6 +17,7 @@ import org.springframework.stereotype.Service;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
@@ -31,59 +32,83 @@ public class UserService {
     private final NicknameRepository nicknameRepository;
     private final StringRedisTemplate redisTemplate;
 
-    @Transactional
     public UserSignupResponse registerUser(UserSignupRequest signupDto) {
         signupDto.check();
         validateDuplicateUserAttributes(signupDto.uid(), signupDto.unick());
-        User user = new User(signupDto);
-        validateDuplicateUserAttributes(user);
-        userRepository.save(user);
+        validateLatestAndRequiredTerms(signupDto.agreements());
 
-        termAgreement(user, signupDto);
+        User user = new User(signupDto);
+        userRepository.save(user);
+        saveAgreements(user, signupDto.agreements());
+
         boolean isMarketingAgreed = agreementRepository.findIsAgreedByAgreementId(
-                user, "마케팅 수집 동의" // termId = 3 (마케팅 수집 동의)
                 user, TermTitle.MARKETING_CONSENT.name()
         ).orElse(false);
 
         return new UserSignupResponse(user.getUserId().toString(), isMarketingAgreed);
     }
 
-    private void validateDuplicateUserAttributes(User user) {
     private void validateDuplicateUserAttributes(String email, String nickname) {
 
-        if (userRepository.existsByUserIdentifier(user.getUserIdentifier())) {
         if (userRepository.existsByUserIdentifier(email)) {
             throw new YeogiException(ErrorType.DUPLICATE_EMAIL);
         }
 
-        if (userRepository.existsByNickname(user.getNickname())) {
         if (userRepository.existsByNickname(nickname)) {
             throw new YeogiException(ErrorType.DUPLICATE_NICKNAME);
         }
     }
 
-    private void termAgreement(User user, UserSignupRequest userSignupRequest) {
+    private void validateLatestAndRequiredTerms(List<Map<Long, Boolean>> agreements) {
+        if (agreements == null || agreements.isEmpty()) {
+            throw new YeogiException(ErrorType.TERMS_NOT_FOUND);
+        }
 
-        List<Term> terms = termRepository.findTermsWithLatestTermDetail();
+        List<Term> latestTerms = termRepository.findTermsWithLatestTermDetail();
 
-        List<Agreement> agreements = terms.stream()
-                .map(term -> {
+        // 1. 최신 약관이 아닌 ID가 포함되었는지 검증
+        Set<Long> latestTermIds = latestTerms.stream()
+                .map(Term::getTermId)
+                .collect(Collectors.toSet());
 
-                    boolean isAgreed = term.isRequired() ||
-                            switch (term.getTermId().intValue()) {
-                                case 2 -> userSignupRequest.privacyAuxiliaryPolicy();
-                                case 3 -> userSignupRequest.marketingAcceptance();
-                                case 4 -> userSignupRequest.locationPolicy();
-                                default -> false;
-                            };
+        Set<Long> providedTermIds = agreements.stream()
+                .flatMap(map -> map.keySet().stream())
+                .collect(Collectors.toSet());
 
-                    return new Agreement(new AgreementId(user, term.getTitle(), term.getVersion()), isAgreed);
-                })
-                .collect(Collectors.toList());
+        if (!providedTermIds.containsAll(latestTermIds)) {
+            throw new YeogiException(ErrorType.SIGNUP_INVALID_TERM_ID);
+        }
 
-        agreementRepository.saveAll(agreements);
+        // 2. 필수 약관이 모두 동의되었는지 검증
+        Map<Long, Boolean> agreementMap = agreements.stream()
+                .flatMap(map -> map.entrySet().stream())
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+        boolean allRequiredTermsAgreed = latestTerms.stream()
+                .filter(Term::isRequired)
+                .allMatch(term -> Boolean.TRUE.equals(agreementMap.get(term.getTermId())));
+
+        if (!allRequiredTermsAgreed) {
+            throw new YeogiException(ErrorType.SIGNUP_REQUIRED_TERMS_NOT_ACCEPTED);
+        }
     }
 
+    private void saveAgreements(User user, List<Map<Long, Boolean>> agreements) {
+        List<Term> terms = termRepository.findTermsWithLatestTermDetail();
+
+        Map<Long, Boolean> agreementMap = agreements.stream()
+                .flatMap(map -> map.entrySet().stream())
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+        List<Agreement> agreementList = terms.stream()
+                .map(term -> new Agreement(
+                        new AgreementId(user, term.getTitle(), term.getVersion()),
+                        agreementMap.getOrDefault(term.getTermId(), false)
+                ))
+                .collect(Collectors.toList());
+
+        agreementRepository.saveAll(agreementList);
+    }
 
     public TermResponse getTerms() {
         List<Term> terms = termRepository.findTermsWithLatestTermDetail();
@@ -94,7 +119,6 @@ public class UserService {
         List<TermDto> termDtos = terms.stream()
                 .map(term -> new TermDto(
                         term.getTermId(),
-                        term.getTitle(),
                         TermTitle.valueOf(term.getTitle()).getKoreanTitle(),
                         term.getContent(),
                         term.isRequired()

--- a/src/main/java/com/onerty/yeogi/user/UserService.java
+++ b/src/main/java/com/onerty/yeogi/user/UserService.java
@@ -34,6 +34,7 @@ public class UserService {
     @Transactional
     public UserSignupResponse registerUser(UserSignupRequest signupDto) {
         signupDto.check();
+        validateDuplicateUserAttributes(signupDto.uid(), signupDto.unick());
         User user = new User(signupDto);
         validateDuplicateUserAttributes(user);
         userRepository.save(user);
@@ -48,12 +49,15 @@ public class UserService {
     }
 
     private void validateDuplicateUserAttributes(User user) {
+    private void validateDuplicateUserAttributes(String email, String nickname) {
 
         if (userRepository.existsByUserIdentifier(user.getUserIdentifier())) {
+        if (userRepository.existsByUserIdentifier(email)) {
             throw new YeogiException(ErrorType.DUPLICATE_EMAIL);
         }
 
         if (userRepository.existsByNickname(user.getNickname())) {
+        if (userRepository.existsByNickname(nickname)) {
             throw new YeogiException(ErrorType.DUPLICATE_NICKNAME);
         }
     }

--- a/src/main/java/com/onerty/yeogi/user/UserService.java
+++ b/src/main/java/com/onerty/yeogi/user/UserService.java
@@ -40,7 +40,7 @@ public class UserService {
         userRepository.save(user);
         saveAgreements(user, signupDto.agreements());
 
-        boolean isMarketingAgreed = agreementRepository.findIsAgreedByAgreementId(
+        boolean isMarketingAgreed = agreementRepository.findIsAgreedByUserAndTitle(
                 user, TermTitle.MARKETING_CONSENT.name()
         ).orElse(false);
 

--- a/src/main/java/com/onerty/yeogi/user/UserService.java
+++ b/src/main/java/com/onerty/yeogi/user/UserService.java
@@ -41,6 +41,7 @@ public class UserService {
         termAgreement(user, signupDto);
         boolean isMarketingAgreed = agreementRepository.findIsAgreedByAgreementId(
                 user, "마케팅 수집 동의" // termId = 3 (마케팅 수집 동의)
+                user, TermTitle.MARKETING_CONSENT.name()
         ).orElse(false);
 
         return new UserSignupResponse(user.getUserId().toString(), isMarketingAgreed);
@@ -90,6 +91,7 @@ public class UserService {
                 .map(term -> new TermDto(
                         term.getTermId(),
                         term.getTitle(),
+                        TermTitle.valueOf(term.getTitle()).getKoreanTitle(),
                         term.getContent(),
                         term.isRequired()
                 ))

--- a/src/main/java/com/onerty/yeogi/user/dto/UserSignupRequest.java
+++ b/src/main/java/com/onerty/yeogi/user/dto/UserSignupRequest.java
@@ -4,6 +4,8 @@ import com.onerty.yeogi.exception.YeogiException;
 import com.onerty.yeogi.exception.ErrorType;
 import com.onerty.yeogi.util.Checkable;
 
+import java.util.List;
+import java.util.Map;
 import java.util.regex.Pattern;
 
 public record UserSignupRequest(
@@ -13,9 +15,7 @@ public record UserSignupRequest(
         String ugender,
         String ubirth,
         String afUserId,
-        boolean locationPolicy,
-        boolean privacyAuxiliaryPolicy,
-        boolean marketingAcceptance,
+        List<Map<Long, Boolean>> agreements,
         String uid,
         String upw
 ) implements Checkable {


### PR DESCRIPTION
## 주요 구현 내용
- 회원가입 약관 동의 방식 개선
	- 기존엔 약관 동의 여부를 개별 boolean 으로 받았었는데 확장성을 고려해  `List<Map<Long, Boolean>>` 형태로 약관 ID와 동의 여부를 전달받도록 수정
	- List 로 변경됨에 따라 약관 유효성 검사 추가
		- 최신 약관 여부 확인
		- 필수 약관 동의 여부 체크
	- 약관 검증과 저장 로직 분리
- 회원가입 로직 개선
	- `validateDuplicateUserAttributes` 는 필요한 값만 파라미터로 받도록 수정
	- dto 단순 유효성 검증은 컨트롤러 레이어에서 수행하도록 수정
	- `@Transactional` 제거
- `Term` title 데이터 한글-> 영문 변경됨에 따라 `TermTitle` enum 추가

## 기타 고려 사항 
- 마케팅 동의 여부(`isMarketingAgreed`)는 회원가입 완료 후 사용자에게 보여주기 위해 별도로 조회하는 방식을 유지 



