### PR TITLE
[#13] 예외 처리 개선

### DIFF
--- a/src/main/java/com/onerty/yeogi/exception/ErrorType.java
+++ b/src/main/java/com/onerty/yeogi/exception/ErrorType.java
@@ -1,7 +1,11 @@
 package com.onerty.yeogi.exception;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
+@Getter
+@AllArgsConstructor
 public enum ErrorType {
 
     TERMS_NOT_FOUND("a0001", HttpStatus.NOT_FOUND, "저장된 약관 내역이 없습니다"),
@@ -11,29 +15,11 @@ public enum ErrorType {
     INVALID_EMAIL_FORMAT("a0005", HttpStatus.BAD_REQUEST, "이메일 형식이 올바르지 않습니다"),
     DUPLICATE_NICKNAME("a0006", HttpStatus.CONFLICT, "이미 사용 중인 닉네임입니다"),
     DUPLICATE_EMAIL("a0007", HttpStatus.CONFLICT, "이미 사용 중인 이메일입니다"),
-    SIGNUP_MISSING_REQUIRED_FIELD("a0008",  HttpStatus.BAD_REQUEST, "회원가입 필수 입력값이 누락되었습니다"),
+    SIGNUP_MISSING_REQUIRED_FIELD("a0008", HttpStatus.BAD_REQUEST, "회원가입 필수 입력값이 누락되었습니다"),
 
     INTERNAL_SERVER_ERROR("common", HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류");
 
     private String code;
     private HttpStatus httpStatus;
     private String message;
-
-    ErrorType(String code, HttpStatus httpStatus, String message) {
-        this.code = code;
-        this.httpStatus = httpStatus;
-        this.message = message;
-    }
-
-    public String getCode() {
-        return code;
-    }
-
-    public HttpStatus getHttpStatus() {
-        return httpStatus;
-    }
-
-    public String getMessage() {
-        return message;
-    }
 }

--- a/src/main/java/com/onerty/yeogi/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/onerty/yeogi/exception/GlobalExceptionHandler.java
@@ -1,19 +1,33 @@
 package com.onerty.yeogi.exception;
 
 import com.onerty.yeogi.util.BaseResponse;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.context.request.WebRequest;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Consumer;
+
 import static com.onerty.yeogi.exception.ErrorType.INTERNAL_SERVER_ERROR;
 
+@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(YeogiException.class)
     public ResponseEntity<BaseResponse.error> handleYeogiException(YeogiException ex, WebRequest request) {
+
         ErrorType errorType = ex.getErrorType();
+        Map<String, Object> parameters = ex.getParameters() != null ? ex.getParameters() : new HashMap<>();
+        Consumer<String> logger = ex.getLogConsumer();
+
+        String errorMessage = String.format("[YeogiException] Type: %s | Message: %s | Parameters: %s\nStackTrace:\n%s",
+                errorType, ex.getMessage(), parameters, getStackTraceAsString(ex));
+
+        logger.accept(errorMessage);
 
         BaseResponse.error errorResponse = new BaseResponse.error(
                 request.getDescription(false),
@@ -25,11 +39,27 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<BaseResponse.error> handleGenericException(Exception ex, WebRequest request) {
+
+        Map<String, Object> parameters = new HashMap<>();
+
+        String errorMessage = String.format("[Unhandled Exception] Path: %s | Message: %s\nStackTrace:\n%s",
+                request.getDescription(false), ex.getMessage(), getStackTraceAsString(ex));
+
+        log.error(errorMessage);
+
         BaseResponse.error errorResponse = new BaseResponse.error(
                 request.getDescription(false),
                 INTERNAL_SERVER_ERROR
         );
 
         return ResponseEntity.status(500).body(errorResponse);
+    }
+
+    private String getStackTraceAsString(Throwable throwable) {
+        StringBuilder sb = new StringBuilder();
+        for (StackTraceElement element : throwable.getStackTrace()) {
+            sb.append("\tat ").append(element).append("\n");
+        }
+        return sb.toString();
     }
 }

--- a/src/main/java/com/onerty/yeogi/exception/YeogiException.java
+++ b/src/main/java/com/onerty/yeogi/exception/YeogiException.java
@@ -1,13 +1,33 @@
 package com.onerty.yeogi.exception;
 
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.event.Level;
+
+import java.util.Map;
+import java.util.function.Consumer;
+
+@Slf4j
+@Getter
 public class YeogiException extends RuntimeException {
+
     ErrorType errorType;
+    Map<String, Object> parameters;
+    Consumer<String> logConsumer;
 
     public YeogiException(ErrorType errorType) {
         this.errorType = errorType;
+        this.logConsumer = log::warn;
     }
 
-    public ErrorType getErrorType() {
-        return errorType;
+    public YeogiException(ErrorType errorType, Consumer<String> logConsumer) {
+        this.errorType = errorType;
+        this.logConsumer = logConsumer;
+    }
+
+    public YeogiException(ErrorType errorType, Map<String, Object> parameters, Consumer<String> logConsumer) {
+        this.errorType = errorType;
+        this.parameters = parameters;
+        this.logConsumer = logConsumer;
     }
 }

--- a/src/main/java/com/onerty/yeogi/user/UserService.java
+++ b/src/main/java/com/onerty/yeogi/user/UserService.java
@@ -11,6 +11,7 @@ import com.onerty.yeogi.user.dto.UserSignupResponse;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.slf4j.event.Level;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 
@@ -83,7 +84,7 @@ public class UserService {
     public TermResponse getTerms() {
         List<Term> terms = termRepository.findTermsWithLatestTermDetail();
         if (terms.isEmpty()) {
-            throw new YeogiException(ErrorType.TERMS_NOT_FOUND);
+            throw new YeogiException(ErrorType.TERMS_NOT_FOUND, log::error);
         }
 
         List<TermDto> termDtos = terms.stream()


### PR DESCRIPTION

## 주요 구현 내용

- YeogiException 
	- `parameters` 예외 발생 시 입력된 값을 포함
	- `logConsumer` 로그 레벨을 동적으로 설정
	- `YeogiException` 사용 예시
	    `throw new YeogiException(ErrorType.TERMS_NOT_FOUND, log::error);`
	- 여러 개의 생성자 추가
	    - `ErrorType`만 지정할 경우 기본 로그 레벨은 `WARN`으로 설정
	    - 특정한 `logConsumer`를 넘길 경우에 해당 로그 레벨 적용 (`log::error` 등)
- `handleYeogiException` 예외 로그 출력 방식 
	- `errorMessage` 는 errorType, parameters, StackTrace 포함
	- `logger.accept(errorMessage);` 예외 중요도 별 로깅 구현
	- `getStackTraceAsString()` 스택트레이스 출력을 위한 공통 메소드 추가 
- `ErrorType` 레벨 조정
	- 기존 `ErrorType`은 인증 오류 등 일반적인 예외 상황을 포함하나 ErrorType.TERMS_NOT_FOUND (약관이 조회 안되는 문제) 는 발생하면 안되는 예외이므로 별도로 로그레벨을 지정