### PR TITLE
[#22] customer 모듈에 스프링 시큐리티 적용

### DIFF
--- a/yeogi-customer/build.gradle
+++ b/yeogi-customer/build.gradle
@@ -5,6 +5,10 @@ dependencies {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+    implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation group: 'io.jsonwebtoken', name: 'jjwt', version: '0.9.1'
     implementation 'javax.xml.bind:jaxb-api:2.3.0'
+
+    testImplementation 'org.springframework.security:spring-security-test'
 }

--- a/yeogi-customer/src/main/java/com/onerty/yeogi/customer/auth/AuthController.java
+++ b/yeogi-customer/src/main/java/com/onerty/yeogi/customer/auth/AuthController.java
@@ -6,7 +6,9 @@ import com.onerty.yeogi.customer.auth.dto.LoginRequest;
 import com.onerty.yeogi.customer.auth.dto.LoginResponse;
 import com.onerty.yeogi.customer.auth.dto.TokenRefreshRequest;
 import com.onerty.yeogi.customer.auth.dto.TokenRefreshResponse;
+import com.onerty.yeogi.customer.security.CustomerUserDetails;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import static com.onerty.yeogi.customer.auth.JwtUtil.removeBearerPrefix;
@@ -36,4 +38,10 @@ public class AuthController {
         authService.logout(token);
         return new BaseResponse.success<>(new MessageResponse("로그아웃에 성공했습니다"));
     }
+
+    @GetMapping("/v1/auth/me")
+    public String getMe(@AuthenticationPrincipal CustomerUserDetails userDetails) {
+        return "Hi, " + userDetails.getUsername();
+    }
+
 }

--- a/yeogi-customer/src/main/java/com/onerty/yeogi/customer/auth/AuthService.java
+++ b/yeogi-customer/src/main/java/com/onerty/yeogi/customer/auth/AuthService.java
@@ -32,8 +32,8 @@ public class AuthService {
             throw new YeogiException(ErrorType.INVALID_PASSWORD);
         }
 
-        String accessToken = jwtTokenProvider.generateAccessToken(user);
-        String refreshToken = jwtTokenProvider.generateRefreshToken(user);
+        String accessToken = jwtTokenProvider.generateAccessToken(user.toJwtPayload());
+        String refreshToken = jwtTokenProvider.generateRefreshToken(user.toJwtPayload());
 
         return new LoginResponse(accessToken, refreshToken, user);
     }
@@ -41,7 +41,7 @@ public class AuthService {
     public TokenRefreshResponse refreshToken(TokenRefreshRequest request) {
         String refreshToken = request.refreshToken();
 
-        if (jwtTokenProvider.isInvalidToken(refreshToken)) {
+        if (!jwtTokenProvider.isValidToken(refreshToken)) {
             throw new YeogiException(ErrorType.INVALID_REFRESH_TOKEN);
         }
 
@@ -53,12 +53,12 @@ public class AuthService {
         User user = userRepository.findByUserIdentifier(userId)
                 .orElseThrow(() -> new YeogiException(ErrorType.USER_NOT_FOUND));
 
-        String newAccessToken = jwtTokenProvider.generateAccessToken(user);
+        String newAccessToken = jwtTokenProvider.generateAccessToken(user.toJwtPayload());
         return new TokenRefreshResponse(newAccessToken);
     }
 
     public void logout(String accessToken) {
-        if (jwtTokenProvider.isInvalidToken(accessToken)) {
+        if (!jwtTokenProvider.isValidToken(accessToken)) {
             throw new YeogiException(ErrorType.INVALID_ACCESS_TOKEN);
         }
 

--- a/yeogi-customer/src/main/java/com/onerty/yeogi/customer/auth/JwtTokenProvider.java
+++ b/yeogi-customer/src/main/java/com/onerty/yeogi/customer/auth/JwtTokenProvider.java
@@ -1,7 +1,8 @@
 package com.onerty.yeogi.customer.auth;
 
-import com.onerty.yeogi.customer.user.User;
-import io.jsonwebtoken.*;
+import com.onerty.yeogi.customer.auth.dto.JwtPayload;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
 import org.springframework.stereotype.Component;
 
 import java.util.Date;
@@ -13,28 +14,28 @@ public class JwtTokenProvider {
     private final long ACCESS_TOKEN_EXPIRATION = 60 * 60 * 1000;  // 1시간
     private final long REFRESH_TOKEN_EXPIRATION = 7 * 24 * 60 * 60 * 1000; // 7일
 
-    public String generateAccessToken(User user) {
+    public String generateAccessToken(JwtPayload jwtPayload) {
         return Jwts.builder()
-                .setSubject(user.getUserIdentifier())
+                .setSubject(jwtPayload.userIdentifier())
                 .setExpiration(new Date(System.currentTimeMillis() + ACCESS_TOKEN_EXPIRATION))
                 .signWith(SignatureAlgorithm.HS512, SECRET_KEY)
                 .compact();
     }
 
-    public String generateRefreshToken(User user) {
+    public String generateRefreshToken(JwtPayload jwtPayload) {
         return Jwts.builder()
-                .setSubject(user.getUserIdentifier())
+                .setSubject(jwtPayload.userIdentifier())
                 .setExpiration(new Date(System.currentTimeMillis() + REFRESH_TOKEN_EXPIRATION))
                 .signWith(SignatureAlgorithm.HS512, SECRET_KEY)
                 .compact();
     }
 
-    public boolean isInvalidToken(String token) {
+    public boolean isValidToken(String token) {
         try {
             Jwts.parser().setSigningKey(SECRET_KEY).parseClaimsJws(token);
-            return false;
-        } catch (Exception e) {
             return true;
+        } catch (Exception e) {
+            return false;
         }
     }
 

--- a/yeogi-customer/src/main/java/com/onerty/yeogi/customer/auth/dto/JwtPayload.java
+++ b/yeogi-customer/src/main/java/com/onerty/yeogi/customer/auth/dto/JwtPayload.java
@@ -1,0 +1,7 @@
+package com.onerty.yeogi.customer.auth.dto;
+
+public record JwtPayload(
+        Long userId,
+        String userIdentifier
+) {
+}

--- a/yeogi-customer/src/main/java/com/onerty/yeogi/customer/security/CustomerUserDetails.java
+++ b/yeogi-customer/src/main/java/com/onerty/yeogi/customer/security/CustomerUserDetails.java
@@ -1,0 +1,56 @@
+package com.onerty.yeogi.customer.security;
+
+import com.onerty.yeogi.customer.user.User;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
+
+public class CustomerUserDetails implements UserDetails {
+
+    private final User user;
+
+    public CustomerUserDetails(User user) {
+        this.user = user;
+    }
+
+    public Long getUserId() {
+        return user.getUserId();
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(); // 권한 설정 필요 시 수정
+    }
+
+    @Override
+    public String getPassword() {
+        return user.getUserPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getUserIdentifier();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/yeogi-customer/src/main/java/com/onerty/yeogi/customer/security/CustomerUserDetailsService.java
+++ b/yeogi-customer/src/main/java/com/onerty/yeogi/customer/security/CustomerUserDetailsService.java
@@ -1,0 +1,22 @@
+package com.onerty.yeogi.customer.security;
+
+import com.onerty.yeogi.customer.user.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CustomerUserDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        return userRepository.findByUserIdentifier(username)
+                .map(CustomerUserDetails::new)
+                .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다."));
+    }
+}

--- a/yeogi-customer/src/main/java/com/onerty/yeogi/customer/security/JwtAuthenticationFilter.java
+++ b/yeogi-customer/src/main/java/com/onerty/yeogi/customer/security/JwtAuthenticationFilter.java
@@ -1,0 +1,41 @@
+package com.onerty.yeogi.customer.security;
+
+import com.onerty.yeogi.customer.auth.JwtTokenProvider;
+import com.onerty.yeogi.customer.auth.JwtUtil;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final CustomerUserDetailsService userDetailsService;
+
+    public JwtAuthenticationFilter(JwtTokenProvider jwtTokenProvider,
+                                   CustomerUserDetailsService userDetailsService) {
+        this.jwtTokenProvider = jwtTokenProvider;
+        this.userDetailsService = userDetailsService;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        String token = JwtUtil.removeBearerPrefix(request.getHeader("Authorization"));
+        if (token != null && jwtTokenProvider.isValidToken(token)) {
+            String userId = jwtTokenProvider.getUserIdFromToken(token);
+            UserDetails userDetails = userDetailsService.loadUserByUsername(userId);
+            UsernamePasswordAuthenticationToken auth =
+                    new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+            SecurityContextHolder.getContext().setAuthentication(auth);
+        }
+        filterChain.doFilter(request, response);
+    }
+}

--- a/yeogi-customer/src/main/java/com/onerty/yeogi/customer/security/SecurityConfig.java
+++ b/yeogi-customer/src/main/java/com/onerty/yeogi/customer/security/SecurityConfig.java
@@ -1,0 +1,34 @@
+package com.onerty.yeogi.customer.security;
+
+import com.onerty.yeogi.customer.auth.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final CustomerUserDetailsService customerUserDetailsService;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        return http
+                .csrf().disable()
+                .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/api/users/v1/auth/token").permitAll()
+                        .anyRequest().authenticated()
+                )
+                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider, customerUserDetailsService),
+                        UsernamePasswordAuthenticationFilter.class)
+                .build();
+    }
+}

--- a/yeogi-customer/src/main/java/com/onerty/yeogi/customer/user/User.java
+++ b/yeogi-customer/src/main/java/com/onerty/yeogi/customer/user/User.java
@@ -2,6 +2,7 @@ package com.onerty.yeogi.customer.user;
 
 
 import com.onerty.yeogi.common.util.BaseEntity;
+import com.onerty.yeogi.customer.auth.dto.JwtPayload;
 import com.onerty.yeogi.customer.user.dto.UserSignupRequest;
 import jakarta.persistence.*;
 import lombok.Getter;
@@ -51,4 +52,9 @@ public class User extends BaseEntity {
         this.userIdentifier = dto.uid();
         this.userPassword = dto.upw();
     }
+
+    public JwtPayload toJwtPayload() {
+        return new JwtPayload(this.userId, this.userIdentifier);
+    }
+
 }


### PR DESCRIPTION
## 주요 구현 내용
- 스프링 시큐리티 의존성 추가
- `SecurityConfig` 설정 클래스 작성
  - JWT 기반 인증 설정
  - 경로별 접근 권한 설정 (`/public`은 허용, `/customer/**`는 인증 필요 등)
- `JwtAuthenticationFilter` 구현 및 필터 체인에 등록
- JWT 생성/검증을 위한 `JwtTokenProvider` 유틸 클래스 추가
- 간단한 사용자 인증 정보(`CustomerDetailsService`) 구현


## 참고사항
- 현재 프로젝트는 `common`, `admin`, `customer` 모듈로 구성된 멀티모듈 구조를 사용하고 있음
- 실제 인증을 `customer`, `admin` 모듈에 의존해 처리할 경우 순환참조 이슈가 발생한다
	- common module 이 `securityConfig`, `JwtAuthenticationFilter` 를 포함하면서 하위 모듈의 구현체를 참조하게 되면 하위 모듈에 대해 의존성이 생긴다
	- customer, admin 는 이미 common 모듈을 참조하고 있기 때문에 순환 의존성이 발생하는 문제가 발생하며 이는 멀티모듈 설계 원칙을 위반
- 실제 MSA 환경에서는 인증 책임을 게이트웨이에 위임한다
	- 각 서비스는 인증 로직을 포함하지 않고, 게이트웨이에서 토큰을 검증한 후 사용자 정보를 헤더에 담아 전달받는다
- 현재 서비스는 MSA 처럼 완전히 분리된 게이트웨이가 존재하지 않는 상태이므로 customer 모듈에 한정해 스프링 시큐리티를 적용하는 방법을 채택했다