### PR TITLE
[#25] 숙소 및 방 관련 엔티티 구성

### DIFF
--- a/yeogi-common/src/main/java/com/onerty/yeogi/common/room/Accommodation.java
+++ b/yeogi-common/src/main/java/com/onerty/yeogi/common/room/Accommodation.java
@@ -1,0 +1,32 @@
+package com.onerty.yeogi.common.room;
+
+import jakarta.persistence.*;
+import lombok.*;
+import com.onerty.yeogi.common.user.Host;
+
+
+import java.util.List;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Accommodation {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+    private String location;
+
+    @ManyToOne
+    @JoinColumn(name = "host_id")
+    private Host host;
+
+    @OneToMany(mappedBy = "accommodation", cascade = CascadeType.ALL)
+    private List<RoomType> roomTypes;
+}
+

--- a/yeogi-common/src/main/java/com/onerty/yeogi/common/room/Room.java
+++ b/yeogi-common/src/main/java/com/onerty/yeogi/common/room/Room.java
@@ -1,0 +1,36 @@
+package com.onerty.yeogi.common.room;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Entity
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class Room {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String roomNumber;
+    private String floor;
+
+    @Enumerated(EnumType.STRING)
+    private RoomStatus status;
+
+    public enum RoomStatus {
+        AVAILABLE, UNDER_MAINTENANCE
+    }
+
+    @ManyToOne
+    @JoinColumn(name = "room_type_id")
+    private RoomType roomType;
+
+    private LocalDate date;
+
+}

--- a/yeogi-common/src/main/java/com/onerty/yeogi/common/room/RoomType.java
+++ b/yeogi-common/src/main/java/com/onerty/yeogi/common/room/RoomType.java
@@ -1,0 +1,36 @@
+package com.onerty.yeogi.common.room;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.List;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RoomType {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+
+    private String name;
+    private int capacity;
+    private int pricePerNight;
+    private String description;
+
+    @ManyToOne
+    @JoinColumn(name = "accommodation_id")
+    private Accommodation accommodation;
+
+    @OneToMany(mappedBy = "roomType", cascade = CascadeType.ALL)
+    private List<Room> rooms;
+
+    @OneToMany(mappedBy = "roomType", cascade = CascadeType.ALL)
+    private List<RoomTypeStock> stocks;
+}
+

--- a/yeogi-common/src/main/java/com/onerty/yeogi/common/room/RoomTypeDateId.java
+++ b/yeogi-common/src/main/java/com/onerty/yeogi/common/room/RoomTypeDateId.java
@@ -1,0 +1,19 @@
+package com.onerty.yeogi.common.room;
+
+import jakarta.persistence.Embeddable;
+import lombok.*;
+
+import java.io.Serializable;
+import java.time.LocalDate;
+
+@Embeddable
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode
+public class RoomTypeDateId implements Serializable {
+    private Long roomTypeId;
+    private LocalDate date;
+}
+

--- a/yeogi-common/src/main/java/com/onerty/yeogi/common/room/RoomTypeStock.java
+++ b/yeogi-common/src/main/java/com/onerty/yeogi/common/room/RoomTypeStock.java
@@ -1,0 +1,30 @@
+
+
+
+package com.onerty.yeogi.common.room;
+
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RoomTypeStock {
+
+    @EmbeddedId
+    private RoomTypeDateId id;
+
+    private int stock;
+
+    @ManyToOne
+    @JoinColumn(name = "room_type_id")
+    private RoomType roomType;
+
+}
+

--- a/yeogi-common/src/main/java/com/onerty/yeogi/common/user/Host.java
+++ b/yeogi-common/src/main/java/com/onerty/yeogi/common/user/Host.java
@@ -1,0 +1,28 @@
+package com.onerty.yeogi.common.user;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "host")
+@Getter
+@Setter
+@NoArgsConstructor
+public class Host {
+
+    @Id
+    @Column(name = "host_id")
+    private Long id;
+
+    @Column(name = "business_name")
+    private String businessName;
+
+    @Column(name = "business_contact")
+    private String businessContact;
+
+}


### PR DESCRIPTION
## 주요 구현 내용
- `Accommodation`: 숙소 엔티티, 여러 `RoomType`을 가질 수 있음
- `RoomType`: 숙소 내 방 유형(예: 디럭스룸), 예약 가능한 단위
- `Room`: 실제 예약 가능한 개별 방 (ex. 101호, 102호)
- `RoomTypeStock`: 날짜별 예약 가능 재고 수량
   - 재고 관리용 엔티티로 `Room`과 직접 연결은 되어있지 않음