### PR TITLE
[#28] 숙소 검색 및 상세조회 구현

### DIFF
--- a/yeogi-common/build.gradle
+++ b/yeogi-common/build.gradle
@@ -1,3 +1,11 @@
 dependencies {
+
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
+clean {
+    delete file('src/main/generated')
+}

--- a/yeogi-customer/build.gradle
+++ b/yeogi-customer/build.gradle
@@ -10,5 +10,7 @@ dependencies {
     implementation group: 'io.jsonwebtoken', name: 'jjwt', version: '0.9.1'
     implementation 'javax.xml.bind:jaxb-api:2.3.0'
 
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
     testImplementation 'org.springframework.security:spring-security-test'
 }
+

--- a/yeogi-customer/src/main/java/com/onerty/yeogi/customer/config/QuerydslConfig.java
+++ b/yeogi-customer/src/main/java/com/onerty/yeogi/customer/config/QuerydslConfig.java
@@ -1,0 +1,19 @@
+package com.onerty.yeogi.customer.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+
+    @PersistenceContext
+    private EntityManager em;
+
+    @Bean
+    public JPAQueryFactory queryFactory() {
+        return new JPAQueryFactory(em);
+    }
+}

--- a/yeogi-customer/src/main/java/com/onerty/yeogi/customer/room/RoomController.java
+++ b/yeogi-customer/src/main/java/com/onerty/yeogi/customer/room/RoomController.java
@@ -1,0 +1,46 @@
+
+package com.onerty.yeogi.customer.room;
+
+
+import com.onerty.yeogi.customer.room.dto.SearchAccommodationRequest;
+import com.onerty.yeogi.customer.room.dto.SearchAccommodationResponse;
+import com.onerty.yeogi.customer.room.dto.SearchAccommodationRoomRequest;
+import com.onerty.yeogi.customer.room.dto.SearchAccommodationRoomResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/rooms")
+@RequiredArgsConstructor
+public class RoomController {
+
+    private final RoomService roomService;
+
+    @GetMapping("/page")
+    public Page<SearchAccommodationResponse> searchPage(
+            SearchAccommodationRequest req, Pageable pageable
+    ) {
+        return roomService.searchAccommodationsPage(req, pageable);
+    }
+
+    @GetMapping("/scroll")
+    public List<SearchAccommodationResponse> searchScroll(
+            SearchAccommodationRequest req,
+            @RequestParam(required = false) Long lastId,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        return roomService.searchAccommodationsCursor(req, lastId, size);
+    }
+
+    @GetMapping("/{accommodationId}/rooms")
+    public List<SearchAccommodationRoomResponse> searchRooms(
+            @ModelAttribute SearchAccommodationRoomRequest req
+    ) {
+        return roomService.searchAvailableRoomsByAccommodation(req);
+    }
+}
+

--- a/yeogi-customer/src/main/java/com/onerty/yeogi/customer/room/RoomService.java
+++ b/yeogi-customer/src/main/java/com/onerty/yeogi/customer/room/RoomService.java
@@ -1,0 +1,136 @@
+package com.onerty.yeogi.customer.room;
+
+import com.onerty.yeogi.common.room.QAccommodation;
+import com.onerty.yeogi.common.room.QRoomType;
+import com.onerty.yeogi.common.room.QRoomTypeStock;
+import com.onerty.yeogi.customer.room.dto.SearchAccommodationRequest;
+import com.onerty.yeogi.customer.room.dto.SearchAccommodationResponse;
+import com.onerty.yeogi.customer.room.dto.SearchAccommodationRoomRequest;
+import com.onerty.yeogi.customer.room.dto.SearchAccommodationRoomResponse;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RoomService {
+
+    private final JPAQueryFactory queryFactory;
+
+    public Page<SearchAccommodationResponse> searchAccommodationsPage(
+            SearchAccommodationRequest request, Pageable pageable) {
+
+        QAccommodation accommodation = QAccommodation.accommodation;
+        QRoomType roomType = QRoomType.roomType;
+        QRoomTypeStock stock = QRoomTypeStock.roomTypeStock;
+
+        long daysBetween = ChronoUnit.DAYS.between(request.checkIn(), request.checkOut());
+
+        List<SearchAccommodationResponse> content = queryFactory
+                .select(Projections.constructor(SearchAccommodationResponse.class,
+                        accommodation.name,
+                        accommodation.location,
+                        roomType.pricePerNight.min().as("lowestPrice")))
+                .from(accommodation)
+                .join(accommodation.roomTypes, roomType)
+                .join(roomType.stocks, stock)
+                .where(accommodation.location.eq(request.location()),
+                        roomType.capacity.goe(request.guestCount()),
+                        stock.id.date.between(request.checkIn(), request.checkOut().minusDays(1)),
+                        stock.stock.gt(0))
+                .groupBy(accommodation.id)
+                .having(stock.id.date.countDistinct().eq(daysBetween))
+                .orderBy(accommodation.id.asc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        long total = queryFactory
+                .select(accommodation.id.countDistinct())
+                .from(accommodation)
+                .join(accommodation.roomTypes, roomType)
+                .join(roomType.stocks, stock)
+                .where(accommodation.location.eq(request.location()),
+                        roomType.capacity.goe(request.guestCount()),
+                        stock.id.date.between(request.checkIn(), request.checkOut().minusDays(1)),
+                        stock.stock.gt(0))
+                .groupBy(accommodation.id)
+                .having(stock.id.date.countDistinct().eq(daysBetween))
+                .fetch().size();
+
+        return new PageImpl<>(content, pageable, total);
+    }
+
+    public List<SearchAccommodationResponse> searchAccommodationsCursor(
+            SearchAccommodationRequest request, Long lastId, int pageSize) {
+
+        QAccommodation accommodation = QAccommodation.accommodation;
+        QRoomType roomType = QRoomType.roomType;
+        QRoomTypeStock stock = QRoomTypeStock.roomTypeStock;
+
+        long daysBetween = ChronoUnit.DAYS.between(request.checkIn(), request.checkOut());
+
+        BooleanBuilder condition = new BooleanBuilder()
+                .and(accommodation.location.eq(request.location()))
+                .and(roomType.capacity.goe(request.guestCount()))
+                .and(stock.id.date.between(request.checkIn(), request.checkOut().minusDays(1)))
+                .and(stock.stock.gt(0));
+
+        if (lastId != null) {
+            condition.and(accommodation.id.lt(lastId));
+        }
+
+        return queryFactory
+                .select(Projections.constructor(SearchAccommodationResponse.class,
+                        accommodation.name,
+                        accommodation.location,
+                        roomType.pricePerNight.min().as("lowestPrice")))
+                .from(accommodation)
+                .join(accommodation.roomTypes, roomType)
+                .join(roomType.stocks, stock)
+                .where(condition)
+                .groupBy(accommodation.id)
+                .having(stock.id.date.countDistinct().eq(daysBetween))
+                .orderBy(accommodation.id.desc())
+                .limit(pageSize)
+                .fetch();
+    }
+
+    public List<SearchAccommodationRoomResponse> searchAvailableRoomsByAccommodation(
+            SearchAccommodationRoomRequest request) {
+
+        QRoomType roomType = QRoomType.roomType;
+        QRoomTypeStock stock = QRoomTypeStock.roomTypeStock;
+
+        long daysBetween = ChronoUnit.DAYS.between(request.checkIn(), request.checkOut());
+
+        return queryFactory
+                .select(Projections.constructor(SearchAccommodationRoomResponse.class,
+                        roomType.name,
+                        roomType.capacity,
+                        roomType.pricePerNight.multiply((int) daysBetween).as("price"),
+                        roomType.description))
+                .from(roomType)
+                .join(roomType.stocks, stock)
+                .where(roomType.accommodation.id.eq(request.AccommodationId()),
+                        roomType.capacity.goe(request.guestCount()),
+                        stock.id.date.between(request.checkIn(), request.checkOut().minusDays(1)),
+                        stock.stock.gt(0))
+                .groupBy(roomType.id)
+                .having(stock.id.date.countDistinct().eq(daysBetween))
+                .orderBy(roomType.pricePerNight.asc())
+                .fetch();
+    }
+
+}
+

--- a/yeogi-customer/src/main/java/com/onerty/yeogi/customer/room/dto/ScrollResponse.java
+++ b/yeogi-customer/src/main/java/com/onerty/yeogi/customer/room/dto/ScrollResponse.java
@@ -1,0 +1,10 @@
+package com.onerty.yeogi.customer.room.dto;
+
+import java.util.List;
+
+public record ScrollResponse<T>(
+        List<T> content,
+        Long lastId,      // 리스트에서 마지막 ID
+        boolean hasNext   // 다음 페이지가 있는지 여부
+) {
+}

--- a/yeogi-customer/src/main/java/com/onerty/yeogi/customer/room/dto/SearchAccommodationRequest.java
+++ b/yeogi-customer/src/main/java/com/onerty/yeogi/customer/room/dto/SearchAccommodationRequest.java
@@ -1,0 +1,12 @@
+package com.onerty.yeogi.customer.room.dto;
+
+import java.time.LocalDate;
+
+public record SearchAccommodationRequest(
+        String location,
+        LocalDate checkIn,
+        LocalDate checkOut,
+        int guestCount
+) {
+}
+

--- a/yeogi-customer/src/main/java/com/onerty/yeogi/customer/room/dto/SearchAccommodationResponse.java
+++ b/yeogi-customer/src/main/java/com/onerty/yeogi/customer/room/dto/SearchAccommodationResponse.java
@@ -1,0 +1,8 @@
+package com.onerty.yeogi.customer.room.dto;
+
+public record SearchAccommodationResponse(
+        String name,
+        String location,
+        Integer lowestPrice // 남아있는 숙소 재고에 대해 가장 싼 가격
+) {
+}

--- a/yeogi-customer/src/main/java/com/onerty/yeogi/customer/room/dto/SearchAccommodationRoomRequest.java
+++ b/yeogi-customer/src/main/java/com/onerty/yeogi/customer/room/dto/SearchAccommodationRoomRequest.java
@@ -1,0 +1,12 @@
+package com.onerty.yeogi.customer.room.dto;
+
+import java.time.LocalDate;
+
+public record SearchAccommodationRoomRequest(
+        Long AccommodationId,
+        LocalDate checkIn,
+        LocalDate checkOut,
+        int guestCount
+) {
+
+}

--- a/yeogi-customer/src/main/java/com/onerty/yeogi/customer/room/dto/SearchAccommodationRoomResponse.java
+++ b/yeogi-customer/src/main/java/com/onerty/yeogi/customer/room/dto/SearchAccommodationRoomResponse.java
@@ -1,0 +1,9 @@
+package com.onerty.yeogi.customer.room.dto;
+
+public record SearchAccommodationRoomResponse(
+        String roomName,
+        int capacity,
+        int price, // pricePerNight * (숙박 일수)
+        String description
+) {
+}

--- a/yeogi-customer/src/main/java/com/onerty/yeogi/customer/security/JwtAuthenticationFilter.java
+++ b/yeogi-customer/src/main/java/com/onerty/yeogi/customer/security/JwtAuthenticationFilter.java
@@ -24,10 +24,23 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         this.userDetailsService = userDetailsService;
     }
 
+    // 회원 전용 경로 관리
+    private boolean isProtectedPath(String path) {
+        return path.startsWith("/api/users");
+    }
+
     @Override
     protected void doFilterInternal(HttpServletRequest request,
                                     HttpServletResponse response,
                                     FilterChain filterChain) throws ServletException, IOException {
+        String path = request.getRequestURI();
+
+        if (!isProtectedPath(path)) {
+            // 비회원 경로면 바로 통과
+            filterChain.doFilter(request, response);
+            return;
+        }
+
         String token = JwtUtil.removeBearerPrefix(request.getHeader("Authorization"));
         if (token != null && jwtTokenProvider.isValidToken(token)) {
             String userId = jwtTokenProvider.getUserIdFromToken(token);

--- a/yeogi-customer/src/main/java/com/onerty/yeogi/customer/security/SecurityConfig.java
+++ b/yeogi-customer/src/main/java/com/onerty/yeogi/customer/security/SecurityConfig.java
@@ -24,11 +24,13 @@ public class SecurityConfig {
                 .csrf().disable()
                 .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/users/v1/auth/token").permitAll()
+                        .requestMatchers("/api/**").permitAll() // 모든 API는 일단 허용
                         .anyRequest().authenticated()
                 )
-                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider, customerUserDetailsService),
-                        UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(
+                        new JwtAuthenticationFilter(jwtTokenProvider, customerUserDetailsService),
+                        UsernamePasswordAuthenticationFilter.class
+                )
                 .build();
     }
 }


### PR DESCRIPTION
## 주요 구현 내용
- 목록 검색은 페이징, 무한스크롤 두 방식으로 구현합니다
- 상세 조회는 목록 검색 방식과 무관하게 동일한 엔트포인트를 사용합니다
## 참고사항
- 기존에는 `SecurityConfig`에서 모든 API 경로에 대해 `JwtAuthenticationFilter`가 적용되었으나 회원 전용 경로에만 인증 처리를 적용하기위해 필터 내부에서 경로 조건을 분기하도록 변경되었습니다
- `isProtectedPath` 메서드를 통해 인증 대상 경로를 필터 내부에서 관리하고 비회원 API는 별도 설정 없이 필터에서 자동 통과됩니다