### PR TITLE
[#39] User 엔티티를 common 모듈로 이동

### DIFF
--- a/yeogi-common/src/main/java/com/onerty/yeogi/common/user/User.java
+++ b/yeogi-common/src/main/java/com/onerty/yeogi/common/user/User.java
@@ -1,20 +1,18 @@
-package com.onerty.yeogi.customer.user;
+package com.onerty.yeogi.common.user;
 
 
 import com.onerty.yeogi.common.util.BaseEntity;
-import com.onerty.yeogi.customer.auth.dto.JwtPayload;
-import com.onerty.yeogi.customer.user.dto.UserSignupRequest;
 import jakarta.persistence.*;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 
 @Entity
 @Table(name = "users")
 @Getter
 @Setter
+@Builder
 @NoArgsConstructor
+@AllArgsConstructor
 public class User extends BaseEntity {
 
     @Id
@@ -42,19 +40,5 @@ public class User extends BaseEntity {
 
     @Column(name = "user_password")
     private String userPassword;
-
-    public User(UserSignupRequest dto) {
-        this.userType = dto.signupType();
-        this.nickname = dto.nick();
-        this.phoneNumber = dto.phoneNumber();
-        this.gender = dto.gender();
-        this.birthDate = dto.birth();
-        this.userIdentifier = dto.uid();
-        this.userPassword = dto.upw();
-    }
-
-    public JwtPayload toJwtPayload() {
-        return new JwtPayload(this.userId, this.userIdentifier);
-    }
 
 }

--- a/yeogi-customer/src/main/java/com/onerty/yeogi/customer/auth/AuthService.java
+++ b/yeogi-customer/src/main/java/com/onerty/yeogi/customer/auth/AuthService.java
@@ -2,11 +2,12 @@ package com.onerty.yeogi.customer.auth;
 
 import com.onerty.yeogi.common.exception.ErrorType;
 import com.onerty.yeogi.common.exception.YeogiException;
+import com.onerty.yeogi.common.user.User;
 import com.onerty.yeogi.customer.auth.dto.LoginRequest;
 import com.onerty.yeogi.customer.auth.dto.LoginResponse;
 import com.onerty.yeogi.customer.auth.dto.TokenRefreshRequest;
 import com.onerty.yeogi.customer.auth.dto.TokenRefreshResponse;
-import com.onerty.yeogi.customer.user.User;
+import com.onerty.yeogi.customer.user.UserMapper;
 import com.onerty.yeogi.customer.user.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -32,8 +33,8 @@ public class AuthService {
             throw new YeogiException(ErrorType.INVALID_PASSWORD);
         }
 
-        String accessToken = jwtTokenProvider.generateAccessToken(user.toJwtPayload());
-        String refreshToken = jwtTokenProvider.generateRefreshToken(user.toJwtPayload());
+        String accessToken = jwtTokenProvider.generateAccessToken(UserMapper.toJwtPayload(user));
+        String refreshToken = jwtTokenProvider.generateRefreshToken(UserMapper.toJwtPayload(user));
 
         return new LoginResponse(accessToken, refreshToken, user);
     }
@@ -53,7 +54,7 @@ public class AuthService {
         User user = userRepository.findByUserIdentifier(userId)
                 .orElseThrow(() -> new YeogiException(ErrorType.USER_NOT_FOUND));
 
-        String newAccessToken = jwtTokenProvider.generateAccessToken(user.toJwtPayload());
+        String newAccessToken = jwtTokenProvider.generateAccessToken(UserMapper.toJwtPayload(user));
         return new TokenRefreshResponse(newAccessToken);
     }
 

--- a/yeogi-customer/src/main/java/com/onerty/yeogi/customer/auth/dto/LoginResponse.java
+++ b/yeogi-customer/src/main/java/com/onerty/yeogi/customer/auth/dto/LoginResponse.java
@@ -1,6 +1,6 @@
 package com.onerty.yeogi.customer.auth.dto;
 
-import com.onerty.yeogi.customer.user.User;
+import com.onerty.yeogi.common.user.User;
 
 public record LoginResponse(
         String accessToken,

--- a/yeogi-customer/src/main/java/com/onerty/yeogi/customer/security/CustomerUserDetails.java
+++ b/yeogi-customer/src/main/java/com/onerty/yeogi/customer/security/CustomerUserDetails.java
@@ -1,6 +1,6 @@
 package com.onerty.yeogi.customer.security;
 
-import com.onerty.yeogi.customer.user.User;
+import com.onerty.yeogi.common.user.User;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 

--- a/yeogi-customer/src/main/java/com/onerty/yeogi/customer/term/AgreementId.java
+++ b/yeogi-customer/src/main/java/com/onerty/yeogi/customer/term/AgreementId.java
@@ -1,6 +1,6 @@
 package com.onerty.yeogi.customer.term;
 
-import com.onerty.yeogi.customer.user.User;
+import com.onerty.yeogi.common.user.User;
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;

--- a/yeogi-customer/src/main/java/com/onerty/yeogi/customer/term/AgreementRepository.java
+++ b/yeogi-customer/src/main/java/com/onerty/yeogi/customer/term/AgreementRepository.java
@@ -1,6 +1,6 @@
 package com.onerty.yeogi.customer.term;
 
-import com.onerty.yeogi.customer.user.User;
+import com.onerty.yeogi.common.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 

--- a/yeogi-customer/src/main/java/com/onerty/yeogi/customer/user/UserMapper.java
+++ b/yeogi-customer/src/main/java/com/onerty/yeogi/customer/user/UserMapper.java
@@ -1,0 +1,24 @@
+package com.onerty.yeogi.customer.user;
+
+import com.onerty.yeogi.customer.auth.dto.JwtPayload;
+import com.onerty.yeogi.customer.user.dto.UserSignupRequest;
+import com.onerty.yeogi.common.user.User;
+
+// yeogi-customer 모듈 내의 UserMapper 클래스
+public class UserMapper {
+    public static User from(UserSignupRequest dto) {
+        return User.builder()
+                .userType(dto.signupType())
+                .nickname(dto.nick())
+                .phoneNumber(dto.phoneNumber())
+                .gender(dto.gender())
+                .birthDate(dto.birth())
+                .userIdentifier(dto.uid())
+                .userPassword(dto.upw())
+                .build();
+    }
+
+    public static JwtPayload toJwtPayload(User user) {
+        return new JwtPayload(user.getUserId(), user.getUserIdentifier());
+    }
+}

--- a/yeogi-customer/src/main/java/com/onerty/yeogi/customer/user/UserRepository.java
+++ b/yeogi-customer/src/main/java/com/onerty/yeogi/customer/user/UserRepository.java
@@ -1,5 +1,6 @@
 package com.onerty.yeogi.customer.user;
 
+import com.onerty.yeogi.common.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 

--- a/yeogi-customer/src/main/java/com/onerty/yeogi/customer/user/UserService.java
+++ b/yeogi-customer/src/main/java/com/onerty/yeogi/customer/user/UserService.java
@@ -4,6 +4,7 @@ import com.onerty.yeogi.common.exception.ErrorType;
 import com.onerty.yeogi.common.exception.YeogiException;
 import com.onerty.yeogi.common.term.Term;
 import com.onerty.yeogi.common.term.TermTitle;
+import com.onerty.yeogi.common.user.User;
 import com.onerty.yeogi.customer.term.Agreement;
 import com.onerty.yeogi.customer.term.AgreementId;
 import com.onerty.yeogi.customer.term.AgreementRepository;
@@ -38,7 +39,7 @@ public class UserService {
         validateDuplicateUserAttributes(signupDto.uid(), signupDto.nick());
         validateLatestAndRequiredTerms(signupDto.agreements());
 
-        User user = new User(signupDto);
+        User user = UserMapper.from(signupDto);
         userRepository.save(user);
         saveAgreements(user, signupDto.agreements());
 


### PR DESCRIPTION
## 주요 구현내용
- 기존 customer 모듈에 있던 `User` 엔티티를 상위 공통 모듈로 이동해서 여러 기능 간 엔티티 연관 관계를 명확히 관리할 수 있도록 함
- `User` 엔티티 내 로직은 `UserMapper` 정적 유틸 클래스로 분리
- 관련된 import 경로 수정

## 참고 사항
- `User`는 도메인상 공통 객체에 해당하므로 별도 공통 모듈에서 관리하는 것이 구조상 적절함