### PR TITLE
[#44] 공통 시간 측정 기능 common 모듈에 추가

### DIFF
--- a/yeogi-common/build.gradle
+++ b/yeogi-common/build.gradle
@@ -4,6 +4,7 @@ dependencies {
     annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
 }
 
 clean {

--- a/yeogi-common/src/main/java/com/onerty/yeogi/common/aop/AopTimedSample.java
+++ b/yeogi-common/src/main/java/com/onerty/yeogi/common/aop/AopTimedSample.java
@@ -1,0 +1,18 @@
+package com.onerty.yeogi.common.aop;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class AopTimedSample {
+
+    @Timed
+    public void simulateLogic() {
+        try {
+            Thread.sleep(1000); // 일부러 딜레이
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+
+        System.out.println("샘플 로직 실행 완료 🧪");
+    }
+}

--- a/yeogi-common/src/main/java/com/onerty/yeogi/common/aop/AopTimedSampleRunner.java
+++ b/yeogi-common/src/main/java/com/onerty/yeogi/common/aop/AopTimedSampleRunner.java
@@ -1,0 +1,18 @@
+package com.onerty.yeogi.common.aop;
+
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+
+//@Component // 주석 해제 시 common 애플리케이션 실행 시 자동 실행
+@RequiredArgsConstructor
+public class AopTimedSampleRunner implements CommandLineRunner {
+
+    private final AopTimedSample aopTimedSample;
+
+    @Override
+    public void run(String... args) throws Exception {
+        aopTimedSample.simulateLogic();
+    }
+}

--- a/yeogi-common/src/main/java/com/onerty/yeogi/common/aop/TimeLoggingAspect.java
+++ b/yeogi-common/src/main/java/com/onerty/yeogi/common/aop/TimeLoggingAspect.java
@@ -1,0 +1,26 @@
+package com.onerty.yeogi.common.aop;
+
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+@Slf4j
+public class TimeLoggingAspect {
+
+    @Around("@annotation(com.onerty.yeogi.common.aop.Timed)")
+    public Object logExecutionTime(ProceedingJoinPoint joinPoint) throws Throwable {
+        long start = System.currentTimeMillis();
+
+        Object result = joinPoint.proceed();  // 실제 메서드 실행
+
+        long end = System.currentTimeMillis();
+        String methodName = joinPoint.getSignature().toShortString();
+        log.info("️ {} 실행 시간: {} ms", methodName, (end - start));
+
+        return result;
+    }
+}

--- a/yeogi-common/src/main/java/com/onerty/yeogi/common/aop/Timed.java
+++ b/yeogi-common/src/main/java/com/onerty/yeogi/common/aop/Timed.java
@@ -1,0 +1,11 @@
+package com.onerty.yeogi.common.aop;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Timed {
+}


### PR DESCRIPTION
## 주요 구현 내용
- yeogi-common 모듈에 메서드 시간을 측정하는 AOP 작성
  - `@Timed` 메서드 단위 시간 측정용 커스텀 어노테이션
  - `TimeLoggingAspect` @Timed 어노테이션이 붙은 메서드 실행 시간 로그 출력
  - 로그 포맷: 클래스명.메서드명 실행 시간: n ms
  - `AopTimedSample` 해당 모듈에서 AOP 동작 테스트