### PR TITLE
[#38] 예약 및 결제에 동시성 이슈 고려해서 락 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,8 @@ subprojects {
         annotationProcessor 'org.projectlombok:lombok'
         implementation 'org.springframework.boot:spring-boot-starter-web'
         implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+        implementation 'p6spy:p6spy:3.9.1'
+
         developmentOnly 'org.springframework.boot:spring-boot-docker-compose'
         runtimeOnly 'com.mysql:mysql-connector-j'
         testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/yeogi-batch/src/main/java/com/onerty/yeogi/batch/room/repository/ActualRoomRepository.java
+++ b/yeogi-batch/src/main/java/com/onerty/yeogi/batch/room/repository/ActualRoomRepository.java
@@ -1,5 +1,6 @@
 package com.onerty.yeogi.batch.room.repository;
 
+import com.onerty.yeogi.batch.room.repository.projections.ActualRoomProjection;
 import com.onerty.yeogi.common.room.ActualRoom;
 import com.onerty.yeogi.common.room.RoomType;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -7,6 +8,8 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
 
 public interface ActualRoomRepository extends JpaRepository<ActualRoom, Long> {
 
@@ -16,6 +19,14 @@ public interface ActualRoomRepository extends JpaRepository<ActualRoom, Long> {
             "GROUP BY ar.roomType.id")
     List<RoomTypeCountProjection> countRoomsGroupedByRoomType(@Param("accommodationIds") List<Long> accommodationIds);
 
-    int countByRoomType(RoomType roomType);
+
+    @Query("""
+        select 
+            a.id as id, 
+            a.roomNumber as roomNumber, 
+            a.floor as floor
+        from ActualRoom a
+    """)
+    Stream<ActualRoomProjection> streamAllActualRoom();
 
 }

--- a/yeogi-batch/src/main/java/com/onerty/yeogi/batch/room/repository/RoomRepository.java
+++ b/yeogi-batch/src/main/java/com/onerty/yeogi/batch/room/repository/RoomRepository.java
@@ -11,5 +11,4 @@ public interface RoomRepository extends JpaRepository<Room, Long> {
 
     int countByRoomTypeAndDate(RoomType roomType, LocalDate date);
 
-    boolean existsByRoomTypeAndDate(RoomType roomType, LocalDate date);
 }

--- a/yeogi-batch/src/main/java/com/onerty/yeogi/batch/room/repository/RoomTypeRepository.java
+++ b/yeogi-batch/src/main/java/com/onerty/yeogi/batch/room/repository/RoomTypeRepository.java
@@ -1,8 +1,20 @@
 package com.onerty.yeogi.batch.room.repository;
 
 
+import com.onerty.yeogi.batch.room.repository.projections.RoomTypeIdAccommodationIdProjection;
 import com.onerty.yeogi.common.room.RoomType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+import java.util.stream.Stream;
 
 public interface RoomTypeRepository extends JpaRepository<RoomType, Long> {
+
+    @Query("""
+    SELECT r.id AS id, r.accommodation.id AS accommodationId
+    FROM RoomType r
+    """)
+    Stream<RoomTypeIdAccommodationIdProjection> streamAllIdAndAccommodationId();
+
 }

--- a/yeogi-batch/src/main/java/com/onerty/yeogi/batch/room/repository/projections/ActualRoomProjection.java
+++ b/yeogi-batch/src/main/java/com/onerty/yeogi/batch/room/repository/projections/ActualRoomProjection.java
@@ -1,0 +1,4 @@
+package com.onerty.yeogi.batch.room.repository.projections;
+
+public interface ActualRoomProjection {
+}

--- a/yeogi-batch/src/main/java/com/onerty/yeogi/batch/room/repository/projections/RoomTypeIdAccommodationIdProjection.java
+++ b/yeogi-batch/src/main/java/com/onerty/yeogi/batch/room/repository/projections/RoomTypeIdAccommodationIdProjection.java
@@ -1,0 +1,6 @@
+package com.onerty.yeogi.batch.room.repository.projections;
+
+public interface RoomTypeIdAccommodationIdProjection {
+    Long getId();
+    Long getAccommodationId();
+}

--- a/yeogi-batch/src/main/java/com/onerty/yeogi/batch/room/test/RoomQueryTestRunner.java
+++ b/yeogi-batch/src/main/java/com/onerty/yeogi/batch/room/test/RoomQueryTestRunner.java
@@ -1,0 +1,42 @@
+package com.onerty.yeogi.batch.room.test;
+import com.onerty.yeogi.batch.room.repository.*;
+import com.onerty.yeogi.batch.room.repository.projections.ActualRoomProjection;
+import com.onerty.yeogi.common.aop.Timed;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+
+import org.springframework.batch.item.ItemReader;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import java.util.concurrent.atomic.AtomicLong;
+
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+
+
+//@Component
+@RequiredArgsConstructor
+@Slf4j
+public class RoomQueryTestRunner implements CommandLineRunner {
+
+    private final ActualRoomRepository actualRoomRepository;
+
+    @Timed
+    @Override
+    @Transactional(readOnly = true)
+    public void run(String... args) {
+        System.out.println( "⚒️️ ... RoomQueryTestRunner 실행 중");
+
+        try (Stream<ActualRoomProjection> stream = actualRoomRepository.streamAllActualRoom()) {
+            long count = stream
+                    .count(); // 총 개수 확인
+            System.out.println("총 조회 수 = " + count);
+        }
+    }
+}
+
+
+

--- a/yeogi-batch/src/main/resources/application.yaml
+++ b/yeogi-batch/src/main/resources/application.yaml
@@ -20,6 +20,8 @@ spring:
         dialect: org.hibernate.dialect.MySQL8Dialect
         jdbc:
           batch_size: 100
+          fetch_size: 100000
+        default_batch_fetch_size: 100
         order_updates: true
         order_inserts: true
         id:

--- a/yeogi-batch/src/main/resources/application.yaml
+++ b/yeogi-batch/src/main/resources/application.yaml
@@ -7,10 +7,10 @@ spring:
       enabled: false
 
   datasource:
-    url: ${DB_URL}
+    url: ${P6SPY_DB_URL}
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
-    driver-class-name: com.mysql.cj.jdbc.Driver
+    driver-class-name: com.p6spy.engine.spy.P6SpyDriver
 
   jpa:
     hibernate:
@@ -40,9 +40,10 @@ server:
 
 logging:
   level:
+    com.p6spy: DEBUG
     org:
       hibernate:
-        SQL: DEBUG
+        SQL: OFF
         type:
           descriptor:
             sql:

--- a/yeogi-batch/src/main/resources/spy.properties
+++ b/yeogi-batch/src/main/resources/spy.properties
@@ -1,0 +1,4 @@
+
+logMessageFormat=com.p6spy.engine.spy.appender.SingleLineFormat
+appender=com.p6spy.engine.spy.appender.Slf4JLogger
+logLevel=INFO

--- a/yeogi-common/src/main/java/com/onerty/yeogi/common/aop/TimeLoggingAspect.java
+++ b/yeogi-common/src/main/java/com/onerty/yeogi/common/aop/TimeLoggingAspect.java
@@ -19,7 +19,7 @@ public class TimeLoggingAspect {
 
         long end = System.currentTimeMillis();
         String methodName = joinPoint.getSignature().toShortString();
-        log.info("️ {} 실행 시간: {} ms", methodName, (end - start));
+        log.info("️⏰ {} 실행 시간: {} ms", methodName, (end - start));
 
         return result;
     }

--- a/yeogi-common/src/main/java/com/onerty/yeogi/common/exception/ErrorType.java
+++ b/yeogi-common/src/main/java/com/onerty/yeogi/common/exception/ErrorType.java
@@ -47,6 +47,9 @@ public enum ErrorType {
     PAYMENT_NOT_FOUND_OR_ALREADY_CANCELED("p0001", HttpStatus.BAD_REQUEST, "결제 정보가 없거나 이미 취소된 결제입니다."),
     STOCK_NOT_FOUND("s0001", HttpStatus.NOT_FOUND, "재고 정보가 없습니다."),
 
+    LOCK_ACQUISITION_FAILED("l0001", HttpStatus.CONFLICT, "락을 획득하지 못했습니다."),
+    LOCK_INTERRUPTED("l0002", HttpStatus.INTERNAL_SERVER_ERROR, "락 대기 중 인터럽트가 발생했습니다."),
+    CONCURRENT_RESERVATION_CONFLICT("l0003",  HttpStatus.CONFLICT, "이미 결제된 예약입니다"),
     INTERNAL_SERVER_ERROR("common", HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류");
 
     private String code;

--- a/yeogi-common/src/main/java/com/onerty/yeogi/common/room/Reservation.java
+++ b/yeogi-common/src/main/java/com/onerty/yeogi/common/room/Reservation.java
@@ -50,4 +50,7 @@ public class Reservation extends BaseEntity {
         room.setReservation(this);
     }
 
+    @Version
+    private Long version;
+
 }

--- a/yeogi-common/src/main/java/com/onerty/yeogi/common/room/Room.java
+++ b/yeogi-common/src/main/java/com/onerty/yeogi/common/room/Room.java
@@ -2,16 +2,14 @@ package com.onerty.yeogi.common.room;
 
 import com.onerty.yeogi.common.room.enums.RoomStatus;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 import java.time.LocalDate;
 
 @Entity
 @Builder
 @Setter
+@Getter
 @AllArgsConstructor
 @NoArgsConstructor
 public class Room {

--- a/yeogi-customer/build.gradle
+++ b/yeogi-customer/build.gradle
@@ -9,6 +9,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation group: 'io.jsonwebtoken', name: 'jjwt', version: '0.9.1'
     implementation 'javax.xml.bind:jaxb-api:2.3.0'
+    implementation 'org.redisson:redisson-spring-boot-starter:3.23.2'
 
     implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
     testImplementation 'org.springframework.security:spring-security-test'

--- a/yeogi-customer/src/main/java/com/onerty/yeogi/customer/config/RedissonConfig.java
+++ b/yeogi-customer/src/main/java/com/onerty/yeogi/customer/config/RedissonConfig.java
@@ -1,0 +1,18 @@
+package com.onerty.yeogi.customer.config;
+
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RedissonConfig {
+
+    @Bean
+    public RedissonClient redissonClient() {
+        Config config = new Config();
+        config.useSingleServer().setAddress("redis://localhost:6379");
+        return Redisson.create(config);
+    }
+}

--- a/yeogi-customer/src/main/java/com/onerty/yeogi/customer/utils/DistributedLockExecutor.java
+++ b/yeogi-customer/src/main/java/com/onerty/yeogi/customer/utils/DistributedLockExecutor.java
@@ -1,0 +1,41 @@
+package com.onerty.yeogi.customer.utils;
+
+
+import com.onerty.yeogi.common.exception.ErrorType;
+import com.onerty.yeogi.common.exception.YeogiException;
+import lombok.RequiredArgsConstructor;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+@Component
+@RequiredArgsConstructor
+public class DistributedLockExecutor {
+
+    private final RedissonClient redissonClient;
+
+    public <T> T executeWithLock(String lockKey, long waitTimeSec, long leaseTimeSec, Supplier<T> action) {
+        RLock lock = redissonClient.getLock(lockKey);
+
+        try {
+            boolean isLocked = lock.tryLock(waitTimeSec, leaseTimeSec, TimeUnit.SECONDS);
+            if (!isLocked) {
+                throw new YeogiException(ErrorType.LOCK_ACQUISITION_FAILED);
+            }
+
+            return action.get();
+
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new YeogiException(ErrorType.LOCK_INTERRUPTED);
+
+        } finally {
+            if (lock.isHeldByCurrentThread()) {
+                lock.unlock(); // 락 해제
+            }
+        }
+    }
+}

--- a/yeogi-customer/src/main/resources/spy.properties
+++ b/yeogi-customer/src/main/resources/spy.properties
@@ -1,0 +1,3 @@
+logMessageFormat=com.p6spy.engine.spy.appender.MultiLineFormat
+appender=com.p6spy.engine.spy.appender.Slf4JLogger
+logLevel=debug


### PR DESCRIPTION

## 주요 구현 내용

### Room 예약 시: 분산락(Redis 기반) 적용
- 구현 내용
	- 예약 요청 기간(checkIn ~ checkOut)에 해당하는 Room들을 조회하여 예약 진행
	- 각 Room 단위로 Redis 분산락(`lock:room:{roomId}`) 적용
	- 락 획득 후 Room 상태 재확인 및 `RESERVED` 상태로 변경
	- 동시에 RoomTypeStock 재고도 1씩 차감
	- `DistributedLockExecutor` 유틸 클래스를 통해 락 로직을 메서드 기반으로 추상화

- 적용 이유
	- 여러 사용자가 동일한 날짜, 동일 RoomType으로 예약 시도 시 중복 예약 및 재고 음수 발생 가능성 존재
	- 실제 재고 단위는 `Room`이므로 `roomId` 기준으로 락을 적용하여 예약 충돌 방지
	- 락 순서 통일을 위해 `roomId` 정렬 후 순차적으로 락 획득

### 결제 시: Reservation에 낙관적 락 적용
- 구현 내용
	- Reservation 엔티티에 `@Version` 필드 추가하여 낙관적 락 적용
	- 동일한 Reservation에 대해 동시에 결제가 발생할 경우, 버전 충돌로 한 건만 성공

- 적용 이유
	- 예약 상태(Status)는 한 번만 변경되어야 하며, 중복 결제를 방지해야 함
	- Reservation이 보호 대상이므로, Payment가 아니라 Reservation에 `@Version`을 추가
	- 낙관적 락은 경합이 적고, 재시도 가능성이 있는 경우에 성능상 이점이 있다
